### PR TITLE
Avoid duplicate pushes

### DIFF
--- a/patches/nginx_1.11.12_http2_server_push.patch
+++ b/patches/nginx_1.11.12_http2_server_push.patch
@@ -41,14 +41,24 @@ index f3050f1d..88d6dd2c 100644
              break;
          }
 diff --git a/src/http/v2/ngx_http_v2.h b/src/http/v2/ngx_http_v2.h
-index cddfccd2..fbb77025 100644
+index cddfccd2..1b405f69 100644
 --- a/src/http/v2/ngx_http_v2.h
 +++ b/src/http/v2/ngx_http_v2.h
-@@ -141,11 +141,13 @@ struct ngx_http_v2_connection_s {
+@@ -12,6 +12,7 @@
+ #include <ngx_core.h>
+ #include <ngx_http.h>
+ 
++typedef struct ngx_http_v2_push_state ngx_http_v2_push_state_t;
+ 
+ #define NGX_HTTP_V2_ALPN_ADVERTISE       "\x02h2"
+ #define NGX_HTTP_V2_NPN_ADVERTISE        NGX_HTTP_V2_ALPN_ADVERTISE
+@@ -141,11 +142,15 @@ struct ngx_http_v2_connection_s {
      ngx_queue_t                      closed;
  
      ngx_uint_t                       last_sid;
 +    ngx_uint_t                       next_sid;
++
++    ngx_http_v2_push_state_t        *push_state;
  
      unsigned                         closed_nodes:8;
      unsigned                         settings_ack:1;

--- a/src/ngx_http_v2_push.h
+++ b/src/ngx_http_v2_push.h
@@ -7,6 +7,10 @@
 #ifndef _NGX_HTTP_V2_PUSH_H_INCLUDED_
 #define _NGX_HTTP_V2_PUSH_H_INCLUDED_
 
+struct ngx_http_v2_push_state {
+    ngx_array_t  *already_pushed;
+};
+
 #define ngx_http_v2_indexed(i)      (128 + (i))
 
 #define NGX_HTTP_V2_ENCODE_RAW            0

--- a/src/ngx_http_v2_push.h
+++ b/src/ngx_http_v2_push.h
@@ -4,6 +4,8 @@
  * Copyright (C) Valentin V. Bartenev
  */
 
+#ifndef _NGX_HTTP_V2_PUSH_H_INCLUDED_
+#define _NGX_HTTP_V2_PUSH_H_INCLUDED_
 
 #define ngx_http_v2_indexed(i)      (128 + (i))
 
@@ -29,3 +31,5 @@ ngx_http_v2_node_t *ngx_http_v2_get_node_by_id(
     ngx_http_v2_connection_t *h2c, ngx_uint_t sid, ngx_uint_t alloc);
 
 void ngx_http_v2_run_request(ngx_http_request_t *r);
+
+#endif /* _NGX_HTTP_V2_PUSH_H_INCLUDED_ */


### PR DESCRIPTION
Adds a per connection state to track the already pushed paths and avoid duplicate pushes.

Open questions:
 - Using a simple array for the path list now. Question is whether we want to switch to a better data structure. Given that nginx doesn't have a dynamic hash table we could use the `ngx_rbtree`. Given that pushes are limited by `http2_max_pushed_streams` (which doesn't seem to be implemented yet) the array might just work best.
 - Should we fail harder in `ngx_http_v2_push_mark_as_pushed`?